### PR TITLE
Include module prefix in function signatures

### DIFF
--- a/src/main/java/org/expath/exist/crypto/ExistExpathCryptoModule.java
+++ b/src/main/java/org/expath/exist/crypto/ExistExpathCryptoModule.java
@@ -89,12 +89,12 @@ public class ExistExpathCryptoModule extends AbstractInternalModule {
 
 	public static FunctionSignature functionSignature(final String name, final String description,
 			final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
-		return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI), description, returnType, paramTypes);
+		return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
 	}
 
 	public static FunctionSignature[] functionSignatures(final String name, final String description,
 			final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
-		return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI), description, returnType,
+		return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType,
 				variableParamTypes);
 	}
 }


### PR DESCRIPTION
Corresponds to https://github.com/eXist-db/exist/pull/1712 (which did the same for the math module).

Before this PR, searching for "crypto" in the function documentation or in eXide's function autocompletion would return 0 results. With this PR, it returns the crypto module's functions.

Similarly, before, the function documentation showed crypto functions without their prefix:

> <img width="258" alt="Screen Shot 2021-06-30 at 1 58 40 AM" src="https://user-images.githubusercontent.com/59118/123909410-01246580-d947-11eb-914e-988f9055ce71.png">

With this PR:

> <img width="336" alt="Screen Shot 2021-06-30 at 1 58 21 AM" src="https://user-images.githubusercontent.com/59118/123909421-05e91980-d947-11eb-9361-140bc12a9d36.png">

So that inspect:inspect-module-uri and the function documentation show crypto functions with the crypto prefix (e.g., “crypto:hash” instead of “hash”)